### PR TITLE
zellij: init

### DIFF
--- a/modules/home/common/terminals.nix
+++ b/modules/home/common/terminals.nix
@@ -31,6 +31,7 @@ _: {
     btop.enable = true;
     fzf.enable = true;
     yazi.enable = true;
+    zellij.enable = true;
   };
   programs = {
     bat.enable = true;
@@ -56,6 +57,7 @@ _: {
       enableNushellIntegration = true;
       enableZshIntegration = true;
     };
+    zellij.enable = true;
     zoxide.enable = true;
   };
 }

--- a/modules/home/common/terminals.nix
+++ b/modules/home/common/terminals.nix
@@ -62,6 +62,8 @@ _: {
       settings = {
         copy_on_select = false;
         ui.pane_frames.rounded_corners = true;
+        show_startup_tips = false;
+        show_release_notes = false;
       };
     };
     zoxide.enable = true;

--- a/modules/home/common/terminals.nix
+++ b/modules/home/common/terminals.nix
@@ -57,7 +57,13 @@ _: {
       enableNushellIntegration = true;
       enableZshIntegration = true;
     };
-    zellij.enable = true;
+    zellij = {
+      enable = true;
+      settings = {
+        copy_on_select = false;
+        ui.pane_frames.rounded_corners = true;
+      };
+    };
     zoxide.enable = true;
   };
 }


### PR DESCRIPTION
closes #5, seems like this might help with some tasks this semester
- adds zellij through hm
- very basic configuration (might be expanded in the future, but the defaults seem good for now)

todo:
- [x] test on mirage
- [x] test on voyage
- [x] test on refuge
